### PR TITLE
Bump Rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "todo-cli"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/data_ops/access_files/Cargo.toml
+++ b/src/data_ops/access_files/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "access_files"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Note: minimial Rust version is 1.56

See: [Announcing Rust 2021](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html) and [Rust 2021 edition guide](https://doc.rust-lang.org/edition-guide/rust-2021/index.html).

